### PR TITLE
Breve guía de contribución y código de conducta

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -1,0 +1,62 @@
+
+# Contribuyendo
+
+Cuando contribuyas a este repositorio, primero abre un issue para discutir el cambio que deseas realizar o ponte en contacto con los miembros del proyecto para discutirlo previamente.
+
+Ten en cuenta que tenemos un código de conducta, por favor síguelo en todas tus interacciones con el proyecto.
+
+## Proceso de Pull Request
+
+1. Realiza un fork del repositorio principal
+2. Crea una rama(branch) con los cambios usando la estructura: Usuario/Titulo-del-cambio
+3. No agregues cambios a los directorios HTML/PDF. Solo a las fuentes.
+4. Cuando estés listo, abre un Pull Request indicando los cambios que realizaste.
+5. Por el momento, el Pull Request debe ir hacia la rama "main" del repositorio principal.
+
+## Código de conducta
+
+### Nuestro compromiso
+
+Con el fin de fomentar un entorno abierto y de respeto, como colaborador y mantenedor te comprometes a participar en nuestro proyecto con una experiencia libre de acoso para todos, independientemente de la edad, etnia, identidad, expresión de género, nivel de experiencia, nacionalidad, apariencia personal, raza, religión o identidad sexual y orientación.
+
+### Nuestros estándares
+
+Ejemplos de comportamiento que contribuye a crear un entorno positivo.
+incluir:
+
+* Usar un lenguaje amigable
+* Respeta los diferentes puntos de vista y experiencias.
+* Acepta las críticas constructivas
+* Céntrate  en lo que es mejor para el proyecto y la comunidad
+* Muestra empatía hacia otros miembros del proyecto y la comunidad
+
+Ejemplos de comportamiento inaceptable por parte de los participantes incluyen:
+
+* El uso de lenguaje o imágenes sexualizadas
+* Comentarios insultantes/despectivos y ataques personales o políticos
+* Acoso público o privado
+* Publicar información privada de otros, como una información física o electrónica.
+  dirección, sin permiso explícito
+* Otra conducta que razonablemente podría considerarse inapropiada en un
+  entorno profesional
+
+### Nuestras responsabilidades
+
+Los encargados del mantenimiento del proyecto son responsables de aclarar los estándares de comportamiento y se espera que tomen las acciones correctivas apropiadas y justas en respuesta a cualquier caso de comportamiento inaceptable.
+
+Los encargados del mantenimiento del proyecto tienen el derecho y la responsabilidad de eliminar, editar o
+rechazar comentarios, código,  y otras contribuciones que no estén alineados con este Código de Conducta, o para prohibir temporalmente o de forma permanente cualquier colaborador por otros comportamientos que se consideren inapropiados, amenazantes, ofensivos o dañinos.
+
+### Alcance
+
+Este Código de Conducta se aplica tanto en los espacios del proyecto como en los espacios públicos. Cuando un individuo representa el proyecto o su comunidad. Ejemplos de representar un proyecto o comunidad incluye el uso de un correo electrónico oficial del proyecto dirección, publicar a través de una cuenta oficial de redes sociales o actuar como un designado representante en un evento en línea o fuera de línea. La representación del  proyecto puede ser definido y aclarado por los encargados del proyecto.
+
+### Aplicación
+
+Los casos de comportamiento abusivo, acosador o inaceptable pueden ser informado poniéndose en contacto con el equipo del proyecto en [ToDo: DEFINIR MEDIO DE CONTACTO]. Todas las quejas serán revisadas e investigadas y resultarán en una respuesta que se considere necesaria y apropiada a las circunstancias. El equipo del proyecto está obligado a mantener la confidencialidad con respecto al informante de un incidente. 
+
+Los mantenedores de proyectos que no siguen o hacen cumplir el Código de Conducta de manera adecuada pueden enfrentar repercusiones temporales o permanentes según lo determinen otros miembros de la dirección del proyecto.
+
+### Atribución
+
+Este Código de conducta está adaptado del Código de Conducta del Pacto del Colaborador disponible en https://www.contributor-covenant.org/version/1/4/code-of-conduct/


### PR DESCRIPTION
Cuando sea aplicado, generar un link de referencia desde el README hacia la guía de contribución.