### PR TITLE
convertir a 80 caracteres de ancho

### DIFF
--- a/IaC-libro.adoc
+++ b/IaC-libro.adoc
@@ -21,9 +21,31 @@ TODO
 
 === ¿Por qué escribí este libro?
 
-Una gran parte de mi carrera profesional la he dedicado a la automatización y orquestación. Es un tema que me apasiona, sin embargo, la automatización "tradicional" cada vez se ha convertido en un _break and fix_. Es estática y requiere mucho esfuerzo mantener los flujos de trabajo, integraciones y _scripts_ para que la automatización se siga dando en un mundo tan dinámico como el que vivimos en las tecnologías de la información. Desde el primer momento que descubrí los manejadores de configuración, quedé enamorado. En los tiempos de *_CFENGINE_* hacíamos cosas maravillosas que nos permitían enforcarnos realmente a la arquitectura y estrategía en vez de estar configurando pequeñas aplicaciones distribuidas una por una. Podíamos replicar cambios en miles de equipos en un momento. Luego tuve oportunidad de trabajar con *_Chef_* y *_Puppet_*, los cuales son excelentes manejadores de configuración, pero no fue hasta que *_Ansible_* llegó con una forma clara y estandarizada de escribir las configuraciones, que el tema realmente empezó a despegar. Las configuraciones de _Ansible_ están echas en *_YAML_* footnote:[Yet Another Markup Lenguage] Esto permite que sean claramente _leíbles_ por un humano.
+Una gran parte de mi carrera profesional la he dedicado a la automatización y
+orquestación. Es un tema que me apasiona, sin embargo, la automatización
+"tradicional" cada vez se ha convertido en un _break and fix_. Es estática y
+requiere mucho esfuerzo mantener los flujos de trabajo, integraciones y
+_scripts_ para que la automatización se siga dando en un mundo tan dinámico
+como el que vivimos en las tecnologías de la información. Desde el primer
+momento que descubrí los manejadores de configuración, quedé enamorado. En los
+tiempos de *_CFENGINE_* hacíamos cosas maravillosas que nos permitían
+enforcarnos realmente a la arquitectura y estrategía en vez de estar
+configurando pequeñas aplicaciones distribuidas una por una. Podíamos replicar
+cambios en miles de equipos en un momento. Luego tuve oportunidad de trabajar
+con *_Chef_* y *_Puppet_*, los cuales son excelentes manejadores de
+configuración, pero no fue hasta que *_Ansible_* llegó con una forma clara y
+estandarizada de escribir las configuraciones, que el tema realmente empezó a
+despegar. Las configuraciones de _Ansible_ están echas en *_YAML_*
+footnote:[Yet Another Markup Lenguage] Esto permite que sean claramente
+_leíbles_ por un humano.
 
-El tema con _Ansible_ es que fue concebido como un manejador de configuraciones para Sistemas Operativos y aplicaciones, pero faltaba una parte: *La Infraestructura*. No teníamos forma de tratar la configuración de la infraestructura de la misma manera que tratábamos la del sistema operativo o la aplicación. Es ahí donde _Terraform_ brilla, es una herramienta orientada justo a esto último, lo cual facilita meter a la infraestructura en el proceso de *_CI/CD_* footnote:[Continous Integration / Continous Delivery].
+El tema con _Ansible_ es que fue concebido como un manejador de configuraciones
+para Sistemas Operativos y aplicaciones, pero faltaba una parte: *La
+Infraestructura*. No teníamos forma de tratar la configuración de la
+infraestructura de la misma manera que tratábamos la del sistema operativo o la
+aplicación. Es ahí donde _Terraform_ brilla, es una herramienta orientada justo
+a esto último, lo cual facilita meter a la infraestructura en el proceso de
+*_CI/CD_* footnote:[Continous Integration / Continous Delivery].
 
 === ¿Por qué debería de leer este libro?
 
@@ -35,7 +57,8 @@ El tema con _Ansible_ es que fue concebido como un manejador de configuraciones 
 
 === COPIA ESTE LIBRO
 
-¡Sí, copia este libro! Úsalo para cualquier fin, auméntalo, regálalo. Este libro está bajo la licencia CC
+¡Sí, copia este libro! Úsalo para cualquier fin, auméntalo, regálalo. Este
+libro está bajo la licencia CC
 
 include::cap001.adoc[]
 

--- a/Makefile
+++ b/Makefile
@@ -34,3 +34,16 @@ podman-pdf:
 
 podman-epub:
 	podman run --rm -i -v ${PWD}:/documents/:Z ${ACI} make epub
+
+fold: $(SOURCES)
+	@echo "CUIDADO:"; \
+	echo "         Este comando puede romper líneas de código de ejemplo";\
+	echo "         mayores a 80 caracterses." ;\
+	echo ;\
+	echo "  Para salir oprima Control-C o enter para continuar"; \
+	read teclado
+	for file in $^ ; do \
+		fold --spaces --width=80 $${file} > $${file}.tmp ; \
+		mv $${file}.tmp  $${file}; \
+		sed -i 's/[[:space:]]*$$//' $${file}; \
+	done

--- a/bibliografia.adoc
+++ b/bibliografia.adoc
@@ -1,6 +1,10 @@
 [bibliography]
 == Bibliografía
 
-* [[[intro_terraform]]] HashiCorp. (2020). Introduction to Infrastructure as Code with Terraform. 2021, de Hashicorp Sitio web: https://learn.hashicorp.com/tutorials/terraform/infrastructure-as-code?in=terraform/aws-get-started
+* [[[intro_terraform]]] HashiCorp. (2020). Introduction to Infrastructure as
+  Code with Terraform. 2021, de Hashicorp Sitio web:
+  https://learn.hashicorp.com/tutorials/terraform/infrastructure-as-code?in=terraform/aws-get-started
 
-* [[[intro_packer]]] HashiCorp. (2020). Provision Infrastructure with Packer. 2021, de Hashicorp Sitio web: https://learn.hashicorp.com/tutorials/terraform/packer
+* [[[intro_packer]]] HashiCorp. (2020). Provision Infrastructure with Packer.
+  2021, de Hashicorp Sitio web:
+  https://learn.hashicorp.com/tutorials/terraform/packer

--- a/cap001.adoc
+++ b/cap001.adoc
@@ -1,8 +1,22 @@
 == Capítulo 1. Introducción
 
-Para entender la infraestructura como código (IaC por sus siglas en inglés) primero debemos entender qué es infraestructura y qué es código. Infraestructura en el contexto de informática, es el hardware, físico, virtual o lógico que soporta una aplicación o plataforma. Del mismo modo, el código son las instrucciones que permiten crear una aplicación o software. Luego entonces, la infraestructura como código, es la descripción del estado deseado de la configuración de esta infraestructura en un documento, normalmente escrito en texto plano. Al estar escrito en texto plano, esta descripción puede tratarse de la misma manera que se trata un código de software, donde podemos versionarlo, probarlo, compartirlo, etc.
+Para entender la infraestructura como código (IaC por sus siglas en inglés)
+primero debemos entender qué es infraestructura y qué es código.
+Infraestructura en el contexto de informática, es el hardware, físico, virtual
+o lógico que soporta una aplicación o plataforma. Del mismo modo, el código son
+las instrucciones que permiten crear una aplicación o software. Luego entonces,
+la infraestructura como código, es la descripción del estado deseado de la
+configuración de esta infraestructura en un documento, normalmente escrito en
+texto plano. Al estar escrito en texto plano, esta descripción puede tratarse
+de la misma manera que se trata un código de software, donde podemos
+versionarlo, probarlo, compartirlo, etc.
 
-Para hacer esto realidad, debemos contar con un intermediario o intérprete que comprenda esta descripción y la convierta en una configuración que sea entendida por la infraestructura. Esto nos permite automatizar la infraestructura de tal manera que esa configuración la tratemos como software, esto nos da varias ventajas que estaremos discutiendo durante la presente obra, algunas de ellas son:
+Para hacer esto realidad, debemos contar con un intermediario o intérprete que
+comprenda esta descripción y la convierta en una configuración que sea
+entendida por la infraestructura. Esto nos permite automatizar la
+infraestructura de tal manera que esa configuración la tratemos como software,
+esto nos da varias ventajas que estaremos discutiendo durante la presente obra,
+algunas de ellas son:
 
 * Automatización declarativa en vez de imperativa
 * Versionamiento de la configuración
@@ -12,19 +26,63 @@ Para hacer esto realidad, debemos contar con un intermediario o intérprete que 
 === Automatización de Infraestructura
 
 
-La automatización de la infraestructura no es un tema nuevo, es una prácica que existe hace décadas. Dado a la necesidad de hacer más eficiente el despliegue de esta infraestructura, esto se hace mediante *_scripts_* o desarrollos que permiten que esta infraestructura se despliegue automáticamente, el problema con este acercamiento, es que no solo le tenemos que planear qué se va a desplegar, si no tambien cómo se desplegará, por lo que es una automatización *imperativa*. Esto nos acarrea un problema dado que muchas veces la infraestructura no puede ser cambiada una vez desplegada, puesto que en la automatización debemos tener en cuenta todas las excepciones que pudieran ocurrir durante el ciclo de vida de la infraestructura. Por ende, la automatización imperativa funciona muy bien solo para el despliegue de nueva infraestructura, pero no para mantener el ciclo de vida completa de ella. Es decir, despliegue, cambios y decomización.
+La automatización de la infraestructura no es un tema nuevo, es una prácica que
+existe hace décadas. Dado a la necesidad de hacer más eficiente el despliegue
+de esta infraestructura, esto se hace mediante *_scripts_* o desarrollos que
+permiten que esta infraestructura se despliegue automáticamente, el problema
+con este acercamiento, es que no solo le tenemos que planear qué se va a
+desplegar, si no tambien cómo se desplegará, por lo que es una automatización
+*imperativa*. Esto nos acarrea un problema dado que muchas veces la
+infraestructura no puede ser cambiada una vez desplegada, puesto que en la
+automatización debemos tener en cuenta todas las excepciones que pudieran
+ocurrir durante el ciclo de vida de la infraestructura. Por ende, la
+automatización imperativa funciona muy bien solo para el despliegue de nueva
+infraestructura, pero no para mantener el ciclo de vida completa de ella. Es
+decir, despliegue, cambios y decomización.
 
-Más allá de la automatización, existe el concepto de *_orquestación_* en el que normalmente existe un software llamado *orquestador* (*_orchestrator_* en inglés) el cual cuenta con los conectores necesarios para automatizar el despliegue de las diferentes capas de la infraestructura: Almacenamiento, Red, Computo, Sistema Operativo, etc).
+Más allá de la automatización, existe el concepto de *_orquestación_* en el que
+normalmente existe un software llamado *orquestador* (*_orchestrator_* en
+inglés) el cual cuenta con los conectores necesarios para automatizar el
+despliegue de las diferentes capas de la infraestructura: Almacenamiento, Red,
+Computo, Sistema Operativo, etc).
 
-Esto permite "orquestrar" el despliegue de la pila completa de la infraestructura. Pero de la misma manera que se hace al automatizar de manera imperativa, capa por capa, la orquestación imperativa no permite manejar el ciclo de vida completo de la infraestructura.
+Esto permite "orquestrar" el despliegue de la pila completa de la
+infraestructura. Pero de la misma manera que se hace al automatizar de manera
+imperativa, capa por capa, la orquestación imperativa no permite manejar el
+ciclo de vida completo de la infraestructura.
 
 === Manejadores de configuración
 
 
-Los manejadores de configuración, han existido, de igual manera, desde hace décadas, son piezas de software que nos permiten mantener la configuración de un sistema operativo o aplicación de manera declarativa. Es decir, en vez de indicar el qué y el cómo, se describe el qué, es decir se declara el estado deseado de la configuración del Sistema Operativo o aplicación y es el manejador de configuración quien hace la conciliación entre el estado declarado y el estado actual. Es decir, que solo modifica las partes de la configuración que no concuerdan con el estado deseado. Como se manifestó, los Manejadores de configuración (*_Configuration Manager_* en inglés) fueron concebidos para mantener la configuración del Sistema Operativo y/o la aplicación. Con el avance de las tecnologías de virtualización y del concepto de *_Software Defined_*, el despliegue y configuración de la infraestructura, también puede ser declarada y manejada como si de un sistema operativo o una aplicación se tratara.
+Los manejadores de configuración, han existido, de igual manera, desde hace
+décadas, son piezas de software que nos permiten mantener la configuración de
+un sistema operativo o aplicación de manera declarativa. Es decir, en vez de
+indicar el qué y el cómo, se describe el qué, es decir se declara el estado
+deseado de la configuración del Sistema Operativo o aplicación y es el
+manejador de configuración quien hace la conciliación entre el estado declarado
+y el estado actual. Es decir, que solo modifica las partes de la configuración
+que no concuerdan con el estado deseado. Como se manifestó, los Manejadores de
+configuración (*_Configuration Manager_* en inglés) fueron concebidos para
+mantener la configuración del Sistema Operativo y/o la aplicación. Con el
+avance de las tecnologías de virtualización y del concepto de *_Software
+Defined_*, el despliegue y configuración de la infraestructura, también puede
+ser declarada y manejada como si de un sistema operativo o una aplicación se
+tratara.
 
 === El crecimiento de la popularidad de IaC
 
 
-Sin duda, la adopción del *_Cloud Computing_* ha permitido que la IaC se haya popularizado. La disponibilización de las interfaces de programabilidad (APIs), así como el cobro por tiempo utilizado de la infraestructura, han hecho que l IaC sea muy popular para este tipo de modelos de consumo. Sin embargo, también ha influenciado a los fabricantes de infraestructura física, y estos han empezado a disponibilizar _APIs_, así como también han separado el plano de control del plano de datos, que es el principio del _hardware_ definido por _software_. Empresas como *_Hashicorp_* han creado soluciones de IaC que estaremos usando en esta obra, que lleva por nombre *_Terraform_*. Terraform es una herramienta de código abierto para infraestructura como código que provee un flujo de trabajo por linea de comandos consistente para manejar cientos de servicios de nube. Terraform codifica las _APIs_ de las nubes en archivos de configuración declarativa. footnote:[https://www.terraform.io/]
+Sin duda, la adopción del *_Cloud Computing_* ha permitido que la IaC se haya
+popularizado. La disponibilización de las interfaces de programabilidad (APIs),
+así como el cobro por tiempo utilizado de la infraestructura, han hecho que l
+IaC sea muy popular para este tipo de modelos de consumo. Sin embargo, también
+ha influenciado a los fabricantes de infraestructura física, y estos han
+empezado a disponibilizar _APIs_, así como también han separado el plano de
+control del plano de datos, que es el principio del _hardware_ definido por
+_software_. Empresas como *_Hashicorp_* han creado soluciones de IaC que
+estaremos usando en esta obra, que lleva por nombre *_Terraform_*. Terraform es
+una herramienta de código abierto para infraestructura como código que provee
+un flujo de trabajo por linea de comandos consistente para manejar cientos de
+servicios de nube. Terraform codifica las _APIs_ de las nubes en archivos de
+configuración declarativa. footnote:[https://www.terraform.io/]
 

--- a/cap002.adoc
+++ b/cap002.adoc
@@ -1,14 +1,25 @@
 == Capítulo 2. Caso de estudio
 
-A través de este libro estaremos creando los bloques necesarios para mantener la operación de una aplicación mantenida en la nube, la cual cuenta con varios elementos de infraestructura que definiremos como código. La idea de este caso de estudio, será que podamos desplegar esta aplicación, modificarla, escalarla, decomisarla, cambiarla de una región a otra, etc.
+A través de este libro estaremos creando los bloques necesarios para mantener
+la operación de una aplicación mantenida en la nube, la cual cuenta con varios
+elementos de infraestructura que definiremos como código. La idea de este caso
+de estudio, será que podamos desplegar esta aplicación, modificarla, escalarla,
+decomisarla, cambiarla de una región a otra, etc.
 
-El caso de estudio será de la empresa imaginaria de repostería "Galletería Carlota" la cual mantiene su sistema de tienda en linea en la *_Amazon Web Service_* o *_AWS_* como le llamaremos de aquí en adelante. La arquitectura propuesta para la aplicación tiene varias capas o niveles como se muestra en la siguiente figura:
+El caso de estudio será de la empresa imaginaria de repostería "Galletería
+Carlota" la cual mantiene su sistema de tienda en linea en la *_Amazon Web
+Service_* o *_AWS_* como le llamaremos de aquí en adelante. La arquitectura
+propuesta para la aplicación tiene varias capas o niveles como se muestra en la
+siguiente figura:
 
-* Tres (3) Balanceador de Carga nativos de _AWS_ para la capas de presentación, aplicación y base de datos.
+* Tres (3) Balanceador de Carga nativos de _AWS_ para la capas de presentación,
+  aplicación y base de datos.
 * Una *Capa de Presentación _web_* que permite ser escalada verticalmente.
 * Las imágenes de los productos a vender serán almacenadas en un _S3 Bucket_.
-* Una *Capa de Aplicación* que será donde se procese la logíca de negocio la cual tambien debe ser verticalmente escalable.
-* Una *Capa de Base de Datos*, la cual es nativa a la nube y permite ser escalada verticalmente, en este caso usaremos _CoackroachDB_.
+* Una *Capa de Aplicación* que será donde se procese la logíca de negocio la
+  cual tambien debe ser verticalmente escalable.
+* Una *Capa de Base de Datos*, la cual es nativa a la nube y permite ser
+  escalada verticalmente, en este caso usaremos _CoackroachDB_.
 
 .Arquitectura de la Aplicación en AWS
 image::imagenes/App-Arch-Aws.png[]

--- a/cap003.adoc
+++ b/cap003.adoc
@@ -1,12 +1,27 @@
 == Capítulo 3. Introducción a Terraform
 
-Como ya se platicó en el Capítulo 1, durante el desarrollo de esta obra estaremos utilizando la versión abierta y gratuita de *_Hashicorp Terraform_*, la cual ha tomado mucha popularidad entre intenieros que hacen *_DEVOPS_* y *_CI/CD_*, temas que trataremos más adelante. Y no es casualidad, _Terraform_ ofrece un entorno bien documentado y con cientos de integraciones que permiten a las organizaciones tratar su infraestructura como código al escribir archivos con la declaración del estado deseado de las configuraciones. _Terraform_ usa su propio lenguage llamado *_Hashicorp Configuration Language (HLC)_* que permite una descripción concisa de los recursos usando bloques de código, argumentos y expresiones.
+Como ya se platicó en el Capítulo 1, durante el desarrollo de esta obra
+estaremos utilizando la versión abierta y gratuita de *_Hashicorp Terraform_*,
+la cual ha tomado mucha popularidad entre intenieros que hacen *_DEVOPS_* y
+*_CI/CD_*, temas que trataremos más adelante. Y no es casualidad, _Terraform_
+ofrece un entorno bien documentado y con cientos de integraciones que permiten
+a las organizaciones tratar su infraestructura como código al escribir archivos
+con la declaración del estado deseado de las configuraciones. _Terraform_ usa
+su propio lenguage llamado *_Hashicorp Configuration Language (HLC)_* que
+permite una descripción concisa de los recursos usando bloques de código,
+argumentos y expresiones.
 
-De la misma manera, _Terraform_ permite correr las verificaciones necesarias antes de aplicar las configuraciones deseadas para asegurarse que los cambios a realizar son factibles, y el operador tiene oportunidad de entender qué cambios sucederán y como afectará el ambiente desplegado. Una vez hecho esto, el operador puede proceder a aplicar los cambios, para poder llegar al estado deseado solo modificando el delta entre el estado actual y el deseado.
+De la misma manera, _Terraform_ permite correr las verificaciones necesarias
+antes de aplicar las configuraciones deseadas para asegurarse que los cambios a
+realizar son factibles, y el operador tiene oportunidad de entender qué cambios
+sucederán y como afectará el ambiente desplegado. Una vez hecho esto, el
+operador puede proceder a aplicar los cambios, para poder llegar al estado
+deseado solo modificando el delta entre el estado actual y el deseado.
 
 [NOTE]
 ====
-Esta introducción, casi en su totalidad es una traducción simple de la documentación oficial de Hashicorp <<intro_terraform>>.
+Esta introducción, casi en su totalidad es una traducción simple de la
+documentación oficial de Hashicorp <<intro_terraform>>.
 ====
 
 .Código Ejemplo escrito en HCL para AWS
@@ -36,19 +51,30 @@ variable "availability_zone" {
 Algunas de las características más importantes de _Terraform_ son:
 
 
-* *Archivos de Configuración Declarativa:* Definición de Infraestructura como Código para manejar el ciclo de vida completo, creación de nuevos recursos, manejo de los existentes así como la decomisación cuando estos ya no son necesarios.
-* *Modulos instalables:* Intalación automática de modulos de la comunidad o terceros desde el registro de _Hashicorp_ por medio de `terraform init`.
-* *Planeación y predicción de cambios:* _Terraform_ permite a los operadores hacer cambios a la infraestructura de manera segura y predectible.
+* *Archivos de Configuración Declarativa:* Definición de Infraestructura como
+  Código para manejar el ciclo de vida completo, creación de nuevos recursos,
+  manejo de los existentes así como la decomisación cuando estos ya no son
+  necesarios.
+* *Modulos instalables:* Intalación automática de modulos de la comunidad o
+  terceros desde el registro de _Hashicorp_ por medio de `terraform init`.
+* *Planeación y predicción de cambios:* _Terraform_ permite a los operadores
+  hacer cambios a la infraestructura de manera segura y predectible.
 * *Graficación de dependencias
-* *Manejo del estado:* Mapeo de la configuración de los recursos del mundo real, mantenimiento de los _metadatos_ y mejoramiento del _performance_ en infraestructuras grandes
-* *Registro de más de 500 proveedores:* El operador puede escoger de una serie de proveedores para las diferentes plataformas de nube disponibles en el mercado.
+* *Manejo del estado:* Mapeo de la configuración de los recursos del mundo
+  real, mantenimiento de los _metadatos_ y mejoramiento del _performance_ en
+  infraestructuras grandes
+* *Registro de más de 500 proveedores:* El operador puede escoger de una serie
+  de proveedores para las diferentes plataformas de nube disponibles en el
+  mercado.
 
 === Casos de uso
 
-Algunos de los casos de uso que se pueden cubrir con terraform son: footnote:[https://www.terraform.io/intro/use-cases.html]
+Algunos de los casos de uso que se pueden cubrir con terraform son:
+footnote:[https://www.terraform.io/intro/use-cases.html]
 
 * Despliegue de aplicaciones en _Heruku_.
-* Aplicaciones Multi Capa. footnote:[Este es el caso de uso específico que estaremos cubriendo en esta obra.]
+* Aplicaciones Multi Capa. footnote:[Este es el caso de uso específico que
+  estaremos cubriendo en esta obra.]
 * _Clusteres_ de Autoservicio.
 * Demostraciones de _Software_.
 * Ambientes deshechables.
@@ -56,26 +82,41 @@ Algunos de los casos de uso que se pueden cubrir con terraform son: footnote:[ht
 
 === Instalación de _Terraform_
 
-En esta sección estaremos discutiendo la instalación del binario de _Terraform_ en nuestro equipo personal, donde crearemos un ambiente de desarrollo para escribir, probar y desplegar nuestra infraestructura. Existen varios métodos para la instalación de _Terraform_ a continuación discutiremos los más importantes.
+En esta sección estaremos discutiendo la instalación del binario de _Terraform_
+en nuestro equipo personal, donde crearemos un ambiente de desarrollo para
+escribir, probar y desplegar nuestra infraestructura. Existen varios métodos
+para la instalación de _Terraform_ a continuación discutiremos los más
+importantes.
 
 ==== Instalación Manual
 
-Para la instalación manual de _Terraform_, necesitamos encontrar el paquete apropiado footnote:[https://www.terraform.io/downloads.html] para nuestro sistema operativo y bajarlo, este será un archivo _zip_.
+Para la instalación manual de _Terraform_, necesitamos encontrar el paquete
+apropiado footnote:[https://www.terraform.io/downloads.html] para nuestro
+sistema operativo y bajarlo, este será un archivo _zip_.
 
-Una vez que se haya bajado _Terraform_, procederemos a expander el archivo _zip_. Encontraremos que es un solo binario llamado `terraform`. Todos los demás archivos que pudiera contener el archivo _zip_ pueden ser borrados de manera segura sin que esto afecte el funcionamiento de _Terraform_.
+Una vez que se haya bajado _Terraform_, procederemos a expander el archivo
+_zip_. Encontraremos que es un solo binario llamado `terraform`. Todos los
+demás archivos que pudiera contener el archivo _zip_ pueden ser borrados de
+manera segura sin que esto afecte el funcionamiento de _Terraform_.
 
-Finalmente, nos aseguraremos de que `terraform` se encuentre disponible en nuestro `PATH`. Esto se realiza de manera diferente, dependiendo el sistema operativo.
+Finalmente, nos aseguraremos de que `terraform` se encuentre disponible en
+nuestro `PATH`. Esto se realiza de manera diferente, dependiendo el sistema
+operativo.
 
 ===== Mac o Linux
 
-Obtenemos la lista de rutas que están disponibles en la variable de entorno `PATH`
+Obtenemos la lista de rutas que están disponibles en la variable de entorno
+`PATH`
 
 [source,batch]
 ----
 echo $PATH
 ----
 
-Movemos el binario te _Terraform_ a uno de las rutas listadas. Este comando asume que el binario se encuentra en el archivo de descargas y que `PATH` contiene `/usr/local/bin`, personaliza en caso de las rutas en tu sistema operativo sean diferentes.
+Movemos el binario te _Terraform_ a uno de las rutas listadas. Este comando
+asume que el binario se encuentra en el archivo de descargas y que `PATH`
+contiene `/usr/local/bin`, personaliza en caso de las rutas en tu sistema
+operativo sean diferentes.
 
 [source,batch]
 ----
@@ -84,13 +125,18 @@ mv ~/Downloads/terraform /usr/local/bin/
 
 ==== Windows
 
-En la siguiente dirección de internet, podemos encontrar las instrucciones exactas para modificar el `PATH` en _Windows_ através de la interfaz gráfica: `https://stackoverflow.com/questions/1618280/where-can-i-set-path-to-make-exe-on-windows`
+En la siguiente dirección de internet, podemos encontrar las instrucciones
+exactas para modificar el `PATH` en _Windows_ através de la interfaz gráfica:
+`https://stackoverflow.com/questions/1618280/where-can-i-set-path-to-make-exe-on-windows`
 
 ==== Instalación con _Homebrew_ en _MacOS_
 
-_Homebrew_ es un manejador de paquetes de fuente abierta para el sistema operativo _MacOS_. Instala la _formula_ oficial de _Terraform_ desde la terminal.
+_Homebrew_ es un manejador de paquetes de fuente abierta para el sistema
+operativo _MacOS_. Instala la _formula_ oficial de _Terraform_ desde la
+terminal.
 
-Primero, installamos el _tap_ de _HashiCorp_, un repositorio para todos los paquetes de _Homebrew_ de la compañia:
+Primero, installamos el _tap_ de _HashiCorp_, un repositorio para todos los
+paquetes de _Homebrew_ de la compañia:
 
 [source,batch]
 ----
@@ -113,7 +159,8 @@ brew upgrade hashicorp/tap/terraform
 
 ==== Instalación con _Chocolatey_ en _Windows_
 
-_Chocolatey_ es un manejador de paquetes de codigo abierto para _Windows_. Installamos el paquete de _Terraform_ desde la linea de comandos.
+_Chocolatey_ es un manejador de paquetes de codigo abierto para _Windows_.
+Installamos el paquete de _Terraform_ desde la linea de comandos.
 
 [source,batch]
 ----
@@ -136,7 +183,8 @@ Agregamos los repositorios oficiales de _HashiCorp_ para _Linux_.
 
 [source,batch]
 ----
-sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com
+$(lsb_release -cs) main"
 ----
 
 Actualización e instalación.
@@ -155,7 +203,8 @@ Instalamos `yum-config-manager` para manejar repositorios.
 sudo yum install -y yum-utils
 ----
 
-Usamos `yum-config-manager` para agregar el repositorio oficial de _HachiCorp_ para _Linux_
+Usamos `yum-config-manager` para agregar el repositorio oficial de _HachiCorp_
+para _Linux_
 
 [source,batch]
 ----
@@ -178,7 +227,8 @@ Instalamos `dnf config-manager` para manejar repositorios.
 sudo dnf install -y dnf-plugins-core
 ----
 
-Usamos `dnf config-manager` para agregar el repositorio oficial de _HachiCorp_ para _Linux_
+Usamos `dnf config-manager` para agregar el repositorio oficial de _HachiCorp_
+para _Linux_
 
 [source,batch]
 ----
@@ -194,7 +244,8 @@ sudo dnf -y install terraform
 
 ==== Verificación de la instalación.
 
-Para verificar la instalación abrimos una nueva terminal y ejecutamos `terraform -help`
+Para verificar la instalación abrimos una nueva terminal y ejecutamos
+`terraform -help`
 
 [source,batch]
 ----
@@ -207,20 +258,24 @@ less common or more advanced commands.
 ...
 ----
 
-Cualquier sub comando despues de `terraform -help` permite aprender más sobre el mismo.
+Cualquier sub comando despues de `terraform -help` permite aprender más sobre
+el mismo.
 
 [source,batch]
 ----
 terraform -help plan
 ----
 
-Con esto finalizamos la instalación de _Terraform_ y estamos listos para empezar a construir infraestructura como código.
+Con esto finalizamos la instalación de _Terraform_ y estamos listos para
+empezar a construir infraestructura como código.
 
 === Contrucción de Infraestructura
 
-Con _Terraform_ installado, estamos listos para crear nuestra primera infraestructura.
+Con _Terraform_ installado, estamos listos para crear nuestra primera
+infraestructura.
 
-Vamos a aprovisionar una *_Amazon Machine Image (AMI)_* en *_AWS_* esto lo haremos de esta manera, dado que las _AMIs_ son muy populares.
+Vamos a aprovisionar una *_Amazon Machine Image (AMI)_* en *_AWS_* esto lo
+haremos de esta manera, dado que las _AMIs_ son muy populares.
 
 ==== Pre requisitos
 
@@ -230,13 +285,17 @@ Para continuar, necesitamos:
 * La intefaz de linea de comando de _AWS_
 * Las credenciales de _AWS_ configuradas localmente
 
-Esto está descrito en el Apéndice xref:apendice001.adoc[Creación y configuración de una cuenta de Amazon Web Services]
+Esto está descrito en el Apéndice xref:apendice001.adoc[Creación y
+configuración de una cuenta de Amazon Web Services]
 
 ==== Escribir configuraciones
 
-El conjunto de archivos usado para describir la infraestructura en _Terraform_ es conocido como _Terraform Configuration_. Vamos a escribir nuestra primera configuración ahora para lanzar una instancia de _EC2 de AWS_.
+El conjunto de archivos usado para describir la infraestructura en _Terraform_
+es conocido como _Terraform Configuration_. Vamos a escribir nuestra primera
+configuración ahora para lanzar una instancia de _EC2 de AWS_.
 
-Cada configuración debe estar en su propio directorio. Crearemos un directorio para esta nueva configuración.
+Cada configuración debe estar en su propio directorio. Crearemos un directorio
+para esta nueva configuración.
 
 [source,bash]
 ----
@@ -249,7 +308,9 @@ Nos cambiamos al directorio recién creado
 cd iac-libro-aws-instancia
 ----
 
-Pegamos la configuración que está a continuación dentro de un archivo que tenga por nombre `ejemplo.tf` y lo guardamos. _Terraform_ carga todos los archivos en el directorio actual que tengan la extención `.tf`
+Pegamos la configuración que está a continuación dentro de un archivo que tenga
+por nombre `ejemplo.tf` y lo guardamos. _Terraform_ carga todos los archivos en
+el directorio actual que tengan la extención `.tf`
 
 
 [source,bash]
@@ -257,35 +318,74 @@ Pegamos la configuración que está a continuación dentro de un archivo que ten
 include::{sourcedir}/cap003/ejemplo.tf[]
 ----
 
-Esta es una configuración completa de _Terraform_ y está lista para ser aplicada. En las siguientes secciones, veremos como funciona cada uno de estos bloques en más detalle.
+Esta es una configuración completa de _Terraform_ y está lista para ser
+aplicada. En las siguientes secciones, veremos como funciona cada uno de estos
+bloques en más detalle.
 
 ===== Bloques de _Terraform_
 
-El bloque `terraform {}` es requerido para que _Terraform_ conozca qué proveedor tiene que descargar desde el registro de _Terraform_. En la configuración anterior, el proveedor `aws` está definido como `hashicorp/aws` que es una abreviación de `redistry.terraform.io/hashicorp/aws`.
+El bloque `terraform {}` es requerido para que _Terraform_ conozca qué
+proveedor tiene que descargar desde el registro de _Terraform_. En la
+configuración anterior, el proveedor `aws` está definido como `hashicorp/aws`
+que es una abreviación de `redistry.terraform.io/hashicorp/aws`.
 
-También podemos asignar una versión definida en el bloque `required_providers`. El argumento `version` es opcional, pero recomendado.
+También podemos asignar una versión definida en el bloque `required_providers`.
+El argumento `version` es opcional, pero recomendado.
 
 ===== Proveedores
 
-El bloque `provider` configura el nombre del proveedor, en nuestro caso `aws`, que es responsable de crear y manejar los recursos. Un proveedor es un _plugin_ que _Terraform_ usa para traducir las interacciones con las _API_ del servicio a administrar. Un proveedor es el responsable por entender tales interacciones y exponer los recursos. Por el hecho de que _Terraform_ puede interactuar con cualquier _API_, podemos representar casi cualquier tipo de infraestructura como recursos en _Terraform_.
+El bloque `provider` configura el nombre del proveedor, en nuestro caso `aws`,
+que es responsable de crear y manejar los recursos. Un proveedor es un _plugin_
+que _Terraform_ usa para traducir las interacciones con las _API_ del servicio
+a administrar. Un proveedor es el responsable por entender tales interacciones
+y exponer los recursos. Por el hecho de que _Terraform_ puede interactuar con
+cualquier _API_, podemos representar casi cualquier tipo de infraestructura
+como recursos en _Terraform_.
 
-El atributo `profile` en nuestro bloque de proveedor se refiere, en este caso, a las credenciales de _AWS_ almacenadas en la el archivo de configuración de _AWS_, que se creó cuando se hizo la configuración del _CLI_ de _AWS_. La mejor práctica recomendada, es que no se use credenciales directamente en los archivos `.tf`.
+El atributo `profile` en nuestro bloque de proveedor se refiere, en este caso,
+a las credenciales de _AWS_ almacenadas en la el archivo de configuración de
+_AWS_, que se creó cuando se hizo la configuración del _CLI_ de _AWS_. La mejor
+práctica recomendada, es que no se use credenciales directamente en los
+archivos `.tf`.
 
-Pueden existir múltiples bloques de proveedor en caso de ser necesario. Podemos, incluso, usar múltiples proveedores juntos. Por ejemplo, podemos pasar el identificador de una intancia de _AWS_ para monitorear tal recurso con _DataDog_.
+Pueden existir múltiples bloques de proveedor en caso de ser necesario.
+Podemos, incluso, usar múltiples proveedores juntos. Por ejemplo, podemos pasar
+el identificador de una intancia de _AWS_ para monitorear tal recurso con
+_DataDog_.
 
 ===== Recursos
 
-El bloque de `resources` define una pieza de la infraestructura. Un recurso puede er un componente físico o virtual como una instancia de _EC2_, o puede ser un recurso lógico como una _IP elástica_.
+El bloque de `resources` define una pieza de la infraestructura. Un recurso
+puede er un componente físico o virtual como una instancia de _EC2_, o puede
+ser un recurso lógico como una _IP elástica_.
 
-El bloque de recursos tiene dos entradas antes del bloque como tal: el tipo de recurso y el nombre del recurso. en este ejemplo, el tipo de recurso es `aws_instance` y el nombre es `ejemplo`. El prefijo en el tipo de recurso se mapea al proveedor. En nuestro caso `aws_instance` automáticamente le dice a _Terraform_ que este será manejado por el proveedor _aws_.
+El bloque de recursos tiene dos entradas antes del bloque como tal: el tipo de
+recurso y el nombre del recurso. en este ejemplo, el tipo de recurso es
+`aws_instance` y el nombre es `ejemplo`. El prefijo en el tipo de recurso se
+mapea al proveedor. En nuestro caso `aws_instance` automáticamente le dice a
+_Terraform_ que este será manejado por el proveedor _aws_.
 
-Los argumentos del recurso están dentro del bloque del recurso. Los artumentos pueden ser cosas como el tamaño de la máquina, el nombre de la imagen del disco, o identificadores del _VPC_ donde se desplegará la instancia. Para entender los argumentos opcionales y requeridos de cada tipo de recurso, es necesario consultar los documentos de referencia de _HashiCorp_ footnote:[https://www.terraform.io/docs/providers/index.html]. En el caso de la instancia de _EC2_ que crearemos, especificamos un _AMI_ para _Ubuntu_ y el tamaño requerido será `t2.micro` que califica como _free tier_ en nuestra cuenta de _AWS_.
+Los argumentos del recurso están dentro del bloque del recurso. Los artumentos
+pueden ser cosas como el tamaño de la máquina, el nombre de la imagen del
+disco, o identificadores del _VPC_ donde se desplegará la instancia. Para
+entender los argumentos opcionales y requeridos de cada tipo de recurso, es
+necesario consultar los documentos de referencia de _HashiCorp_
+footnote:[https://www.terraform.io/docs/providers/index.html]. En el caso de la
+instancia de _EC2_ que crearemos, especificamos un _AMI_ para _Ubuntu_ y el
+tamaño requerido será `t2.micro` que califica como _free tier_ en nuestra
+cuenta de _AWS_.
 
 ==== Inicializando el directorio
 
-Cuando creamos una nueva configuración (o hacemos _checkout_ de una configuración existente desde el control de versiones) necesitamos inicializar el directorio con `terrarom init`.
+Cuando creamos una nueva configuración (o hacemos _checkout_ de una
+configuración existente desde el control de versiones) necesitamos inicializar
+el directorio con `terrarom init`.
 
-_Terraform_ usa una arquitectura basada en _plugins_ que soporta cientos de proveedores de servicios de infraestructura. Inicializar un directorio de configuracion, descarga e instala los proveedores usados en la configuración qué, en este caso, es el proveedor `aws`. Los comandos subsecuentes, usarán los datos y configuraciones locales hechos durante la inicialización.
+_Terraform_ usa una arquitectura basada en _plugins_ que soporta cientos de
+proveedores de servicios de infraestructura. Inicializar un directorio de
+configuracion, descarga e instala los proveedores usados en la configuración
+qué, en este caso, es el proveedor `aws`. Los comandos subsecuentes, usarán los
+datos y configuraciones locales hechos durante la inicialización.
 
 Iniciemos el directorio.
 
@@ -316,20 +416,30 @@ rerun this command to reinitialize your working directory. If you forget, other
 commands will detect it and remind you to do so if necessary.
 ----
 
-_Terraform_ descarga el proveedor `aws` y lo instala en un subdirectorio oculto en el directorio actual. La salida muestra la versión del plugin que fue instalada.
+_Terraform_ descarga el proveedor `aws` y lo instala en un subdirectorio oculto
+en el directorio actual. La salida muestra la versión del plugin que fue
+instalada.
 
 ==== Formato y validación de la configuración
 
-Una mejor práctica es usar un formato consistente en los archivos y módulos escritos por diferentes equipos. El comando `terraform fmt` automáticamente actualiza la configuración en el directorio actual para una mejor lectura y consistencia.
+Una mejor práctica es usar un formato consistente en los archivos y módulos
+escritos por diferentes equipos. El comando `terraform fmt` automáticamente
+actualiza la configuración en el directorio actual para una mejor lectura y
+consistencia.
 
-Formatearemos nuestra configuración. _Terraform_ retornará los nombres de los archivos formateados. En este caso, nuestro archivo de configuración está de por sí formateado de manera correcta, es por eso que _Terraform_ no retornará ningún nombre de archivo.
+Formatearemos nuestra configuración. _Terraform_ retornará los nombres de los
+archivos formateados. En este caso, nuestro archivo de configuración está de
+por sí formateado de manera correcta, es por eso que _Terraform_ no retornará
+ningún nombre de archivo.
 
 [source,bash]
 ----
 $ terraform fmt
 ----
 
-Para validar que la configuración es sintáctimanete válida usamos el comando `terraform validate`. Si nuestra configuración es válida _Terraform_ retornará un mensaje exitoso.
+Para validar que la configuración es sintáctimanete válida usamos el comando
+`terraform validate`. Si nuestra configuración es válida _Terraform_ retornará
+un mensaje exitoso.
 
 [source,bash]
 ----
@@ -339,7 +449,8 @@ Success! The configuration is valid.
 
 ==== Creación de Infraestructura
 
-En el mismo directorio donde se encuentra `ejemplo.tf` corremos `terraform apply`. Debes ver una salida similar a la mostrada a continuación:
+En el mismo directorio donde se encuentra `ejemplo.tf` corremos `terraform
+apply`. Debes ver una salida similar a la mostrada a continuación:
 
 [source,bash]
 ----
@@ -380,16 +491,28 @@ Do you want to perform these actions?
 
 [TIP]
 ====
-Si tu configuración falla al aplicarse, quizá debas personalizar la región usada o remover el VPC por default.
+Si tu configuración falla al aplicarse, quizá debas personalizar la región
+usada o remover el VPC por default.
 ====
 
-Esta salida nos muestra el plan de ejecución, describiendo qué acciones tomará _Terraform_ para hacer los cambios en la infraestructura real para cumplir con el estado declarado en la configuración.
+Esta salida nos muestra el plan de ejecución, describiendo qué acciones tomará
+_Terraform_ para hacer los cambios en la infraestructura real para cumplir con
+el estado declarado en la configuración.
 
-El formato de la salida es similar al formato de _diff_ generado por herramientas como _Git_. La salida tiene un `+` junto a `aws_instance.ejemplo`, esto significa que _Terraform_ creará este recurso. Debajo de esto, muestra los atributos que serán configurados. Cuando el valor desplegado es `known after apply`, significa que ese valor no será conocido hasta que el recurso no sea creado.
+El formato de la salida es similar al formato de _diff_ generado por
+herramientas como _Git_. La salida tiene un `+` junto a `aws_instance.ejemplo`,
+esto significa que _Terraform_ creará este recurso. Debajo de esto, muestra los
+atributos que serán configurados. Cuando el valor desplegado es `known after
+apply`, significa que ese valor no será conocido hasta que el recurso no sea
+creado.
 
-_Terraform_ quedará en pausa y esperará la aprobación de los cambios antes de proceder. Si algo del plan parece incorrecto o peligroso, podemos abortar de manera segura y ningún cambio será realizado en nuestra infraestructura.
+_Terraform_ quedará en pausa y esperará la aprobación de los cambios antes de
+proceder. Si algo del plan parece incorrecto o peligroso, podemos abortar de
+manera segura y ningún cambio será realizado en nuestra infraestructura.
 
-Si el plan es aceptable, entonces escribimos `yes` en la entrada que nos pide confirmar para proceder. Ejecutar este plan tomará algunos minutos, dado que _Terraform_ espera a que la Instancia _EC2_ esté disponible.
+Si el plan es aceptable, entonces escribimos `yes` en la entrada que nos pide
+confirmar para proceder. Ejecutar este plan tomará algunos minutos, dado que
+_Terraform_ espera a que la Instancia _EC2_ esté disponible.
 
 [source,bash]
 ----
@@ -403,13 +526,22 @@ aws_instance.ejemplo: Creation complete after 34s [id=i-0f57d1b36088f27ae]
 Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
 ----
 
-¡Hemos creado infraestructura hecha con Terraform! En este momento, podemos visitar la consola de _EC2_ para confirmar que se haya creado la instancia. Para esto, hay que estar seguro que tengamos seleccionada la región que fue puesta en nuestra configuración del proveedor.
+¡Hemos creado infraestructura hecha con Terraform! En este momento, podemos
+visitar la consola de _EC2_ para confirmar que se haya creado la instancia.
+Para esto, hay que estar seguro que tengamos seleccionada la región que fue
+puesta en nuestra configuración del proveedor.
 
 ==== Inspección del estado.
 
-Cuando aplicamos la configuración, _Terraform_ escribió datos en un rachivo llamado `terraform.tfstate`. Este archivo ahora contiene los identificadores y propiedades de los recursos que _Terraform_ creó de tal manera que de ahora en adelante puede administrar y destruir los recursos.
+Cuando aplicamos la configuración, _Terraform_ escribió datos en un rachivo
+llamado `terraform.tfstate`. Este archivo ahora contiene los identificadores y
+propiedades de los recursos que _Terraform_ creó de tal manera que de ahora en
+adelante puede administrar y destruir los recursos.
 
-Debemos guardar este archivo de manera segura y distribuirlo solo a los miembros confiables del equipo quienes necesiten manejar nuestra infraestructura. En producción, la mejor práctica es que se almacene este estado de manera remota.
+Debemos guardar este archivo de manera segura y distribuirlo solo a los
+miembros confiables del equipo quienes necesiten manejar nuestra
+infraestructura. En producción, la mejor práctica es que se almacene este
+estado de manera remota.
 
 Inspeccionemos el estado actual usando el comando `terraform show`.
 
@@ -472,11 +604,16 @@ resource "aws_instance" "ejemplo" {
 }
 ----
 
-Cuando _Terraform_ creó esta instancia de _EC2_, también obtuvo mucha información sobre la misma. Estos valores pueden ser referenciados para configurar otros recursos o salidas, esto lo discutiremos más adelante.
+Cuando _Terraform_ creó esta instancia de _EC2_, también obtuvo mucha
+información sobre la misma. Estos valores pueden ser referenciados para
+configurar otros recursos o salidas, esto lo discutiremos más adelante.
 
 ===== Manejando el estado manualmente
 
-_Terraform_ tiene un comando llamado `terraform state` para el manejo avanzado del estado. Por ejemplo, si tenemos un archivo de estado muy grande, podemos listar los recursos que están en el estado, los cuales podemos obtenerlos al ejecutar el subcomando `list`.
+_Terraform_ tiene un comando llamado `terraform state` para el manejo avanzado
+del estado. Por ejemplo, si tenemos un archivo de estado muy grande, podemos
+listar los recursos que están en el estado, los cuales podemos obtenerlos al
+ejecutar el subcomando `list`.
 
 [source,bash]
 ----
@@ -486,15 +623,24 @@ aws_instance.ejemplo
 
 === Cambios a la Infraestructura
 
-Previamente, creamos nuestra primera infraestructura con _Terraform_: una instancia simple de _EC2_. En esta sección, haremos modificaciones a este recurso y veremos como _Terraform_ maneja estos cambios.
+Previamente, creamos nuestra primera infraestructura con _Terraform_: una
+instancia simple de _EC2_. En esta sección, haremos modificaciones a este
+recurso y veremos como _Terraform_ maneja estos cambios.
 
-La infraestructura está en constante evolución, y _Terraform_ fue hecho para ayudar a manejar y hacer estos cambios. Cuando escribimos cambios en las configuraciones de _Terraform_, este creará un plan de ejecución que solo modifica lo que sea necesario para alcanzar el estado deseado.
+La infraestructura está en constante evolución, y _Terraform_ fue hecho para
+ayudar a manejar y hacer estos cambios. Cuando escribimos cambios en las
+configuraciones de _Terraform_, este creará un plan de ejecución que solo
+modifica lo que sea necesario para alcanzar el estado deseado.
 
-Al usar _Terraform_ para hacer cambios en la infraestructura, podemos controlar no solo las versiones de la configuración, sino tambien el estado, de tal manera que podamos ver cómo la infraestructura evoluciona durante el tiempo.
+Al usar _Terraform_ para hacer cambios en la infraestructura, podemos controlar
+no solo las versiones de la configuración, sino tambien el estado, de tal
+manera que podamos ver cómo la infraestructura evoluciona durante el tiempo.
 
 ==== Pre requisitos
 
-Esta sección asume que se realizaron los pasos previos en esta misma obra, si no, debemos crear un directorio llamado `iac-libro-aws-instancia` y pegamos el siguiente código en un archivo llamado `ejemplo.tf`.
+Esta sección asume que se realizaron los pasos previos en esta misma obra, si
+no, debemos crear un directorio llamado `iac-libro-aws-instancia` y pegamos el
+siguiente código en un archivo llamado `ejemplo.tf`.
 
 [source,bash]
 ----
@@ -503,11 +649,14 @@ include::{sourcedir}/cap003/ejemplo.tf[]
 
 ==== Configuración
 
-Ahora actualizaremos el `ami` de nuestra instancia. Cambiemos el recurso `aws_instance.ejemplo` debajo del bloque de proveedor en `ejemplo.tf` reemplazando el identificador del _AMI_ por uno nuevo.
+Ahora actualizaremos el `ami` de nuestra instancia. Cambiemos el recurso
+`aws_instance.ejemplo` debajo del bloque de proveedor en `ejemplo.tf`
+reemplazando el identificador del _AMI_ por uno nuevo.
 
 [TIP]
 ====
-El siguiente código, está en formato _diff_ para darnos en contexto qué debemos cambiar en la configuración
+El siguiente código, está en formato _diff_ para darnos en contexto qué debemos
+cambiar en la configuración
 ====
 
 [source,bash]
@@ -519,11 +668,14 @@ resource "aws_instance" "ejemplo" {
 }
 ----
 
-Esto hará el cambio del _AMI_ a Ubuntu 16.04. Las configuraciones de _Terraform_ están diseñadas para modificarse directamente y sabrá qué tendrá que destruir la antigua instancia y crear una nueva.
+Esto hará el cambio del _AMI_ a Ubuntu 16.04. Las configuraciones de
+_Terraform_ están diseñadas para modificarse directamente y sabrá qué tendrá
+que destruir la antigua instancia y crear una nueva.
 
 ==== Aplicación de los cambios.
 
-Después de cambiar la configuración, corremos `terraform apply` de nuevo para ver cómo _Terraform_ aplicará los cambios a los recursos existentes.
+Después de cambiar la configuración, corremos `terraform apply` de nuevo para
+ver cómo _Terraform_ aplicará los cambios a los recursos existentes.
 
 [source,bash]
 ----

--- a/cap004.adoc
+++ b/cap004.adoc
@@ -1,15 +1,32 @@
 == Capítulo 4. Introducción a Packer
 
 
-Packer es una herramienta de creación de imágenes de código abierto, escrita en Go. Packer también forma parte del stack de *_Hashicorp_*. Este nos permite crear imágenes de máquinas idénticas, para múltiples plataformas de destino desde una única fuente de configuración, lo que facilita la gestión de la configuración y el aprovisionamiento de la infraestructura. Packer es relativamente rápido de aprender y fácil de automatizar. Cuando se usa en combinación con herramientas de administración de configuración, se pueden crear imágenes complejas y totalmente funcionales con software preinstalado y preconfigurado.
+Packer es una herramienta de creación de imágenes de código abierto, escrita en
+Go. Packer también forma parte del stack de *_Hashicorp_*. Este nos permite
+crear imágenes de máquinas idénticas, para múltiples plataformas de destino
+desde una única fuente de configuración, lo que facilita la gestión de la
+configuración y el aprovisionamiento de la infraestructura. Packer es
+relativamente rápido de aprender y fácil de automatizar. Cuando se usa en
+combinación con herramientas de administración de configuración, se pueden
+crear imágenes complejas y totalmente funcionales con software preinstalado y
+preconfigurado.
 
-Una imagen de máquina es una unidad estática que contiene un sistema operativo preconfigurado y un software instalado. Podemos usar imágenes para clonar o crear nuevos hosts. Las imágenes ayudan a acelerar el proceso de construcción y despliegue de nueva infraestructura. Estas existen en muchos formatos, específicos para diversas plataformas y entornos de implementación.
+Una imagen de máquina es una unidad estática que contiene un sistema operativo
+preconfigurado y un software instalado. Podemos usar imágenes para clonar o
+crear nuevos hosts. Las imágenes ayudan a acelerar el proceso de construcción y
+despliegue de nueva infraestructura. Estas existen en muchos formatos,
+específicos para diversas plataformas y entornos de implementación.
 
-Packer es compatible con Linux, Windows y Mac OS X. También es compatible con una amplia variedad de formatos de imagen cmo Amazon EC2, CloudStack, DigitalOcean, Docker, Google Compute Engine, Microsoft Azure, QEMU, VirtualBox, VMware y más. También cuenta con integraciones para otras herramientas, como *_Ansible_* y *_Vagrant_*.
+Packer es compatible con Linux, Windows y Mac OS X. También es compatible con
+una amplia variedad de formatos de imagen cmo Amazon EC2, CloudStack,
+DigitalOcean, Docker, Google Compute Engine, Microsoft Azure, QEMU, VirtualBox,
+VMware y más. También cuenta con integraciones para otras herramientas, como
+*_Ansible_* y *_Vagrant_*.
 
 [NOTE]
 ====
-Esta introducción está basada en la documentación oficial de Hashicorp <<intro_packer>>.
+Esta introducción está basada en la documentación oficial de Hashicorp
+<<intro_packer>>.
 ====
 
 Código Ejemplo de plantilla de Packer para crear una imagen para AWS
@@ -52,59 +69,110 @@ Código Ejemplo de plantilla de Packer para crear una imagen para AWS
 Algunas de las características más importantes de _Packer_ son:
 
 
-* *Rápido despliegue de infraestructura:* las imágenes de Packer permiten lanzar máquinas completamente configuradas y aprovisionadas en segundos. Esto beneficia también a los ambientes de desarrollo, ya que se pueden crear Boxes de Vagrant con Packer, aprovisionadas de la misma manera que en producción, lo que mantiene la paridad.
-* *Detección anticipada de problemas:* Packer instala y configura el software de una máquina en el momento en que se crea la imagen. Si hay errores en este proceso, se detectarán a tiempo en las fases de construcción de un flujo o _pipeline_ de CI/CD en lugar de descubrirlos cuando inicie el entorno.
-* *Basado en constructores para múltiples formatos de imagen:* los constructores o _builders_ leen la configuración y la usan para ejecutar y generar una imagen de máquina virtual. Son constructores: VirtualBox, VMware y Amazon EC2 y más. footnote:[https://www.packer.io/docs/builders]. Los constructores son el equivalente a los proveedores de Terraform.
-* *Portabilidad de entornos:* ya que Packer puede crear imágenes idénticas para múltiples plataformas,es posible ejecutar el entorno de producción en AWS,el entorno de  QA en una nube privada como OpenStack y los entornos de desarrollo en Vagrant.
-* *Soporte para multiples aprovisionadores:* los _provisioners_  son componentes de Packer que instalan y configuran software dentro de una máquina antes de que esta se convierta en una imagen estática. Su principal objetivo es asegurarse que la imagen contenga software útil. Los aprovisionadores de ejemplo incluyen scripts de shell, Ansible, etc. footnote:[https://www.packer.io/docs/provisioners]
+* *Rápido despliegue de infraestructura:* las imágenes de Packer permiten
+  lanzar máquinas completamente configuradas y aprovisionadas en segundos. Esto
+  beneficia también a los ambientes de desarrollo, ya que se pueden crear Boxes
+  de Vagrant con Packer, aprovisionadas de la misma manera que en producción,
+  lo que mantiene la paridad.
+* *Detección anticipada de problemas:* Packer instala y configura el software
+  de una máquina en el momento en que se crea la imagen. Si hay errores en este
+  proceso, se detectarán a tiempo en las fases de construcción de un flujo o
+  _pipeline_ de CI/CD en lugar de descubrirlos cuando inicie el entorno.
+* *Basado en constructores para múltiples formatos de imagen:* los
+  constructores o _builders_ leen la configuración y la usan para ejecutar y
+  generar una imagen de máquina virtual. Son constructores: VirtualBox, VMware y
+  Amazon EC2 y más. footnote:[https://www.packer.io/docs/builders]. Los
+  constructores son el equivalente a los proveedores de Terraform.
+* *Portabilidad de entornos:* ya que Packer puede crear imágenes idénticas para
+  múltiples plataformas,es posible ejecutar el entorno de producción en AWS,el
+  entorno de  QA en una nube privada como OpenStack y los entornos de desarrollo
+  en Vagrant.
+* *Soporte para multiples aprovisionadores:* los _provisioners_  son
+  componentes de Packer que instalan y configuran software dentro de una máquina
+  antes de que esta se convierta en una imagen estática. Su principal objetivo
+  es asegurarse que la imagen contenga software útil. Los aprovisionadores de
+  ejemplo incluyen scripts de shell, Ansible, etc.
+  footnote:[https://www.packer.io/docs/provisioners]
 
 === Casos de uso
 
-Construir imágenes es tedioso. Es normalmente un proceso manual y por lo tanto, es propenso a errores. Packer puede automatizar la creación de imágenes e integrarse bien con herramientas de gestión de configuraciones como Ansible. Packer permite crear pipelines para construir e implementar imágenes, lo que a su vez nos permite producir imágenes consistentes y repetibles.
+Construir imágenes es tedioso. Es normalmente un proceso manual y por lo tanto,
+es propenso a errores. Packer puede automatizar la creación de imágenes e
+integrarse bien con herramientas de gestión de configuraciones como Ansible.
+Packer permite crear pipelines para construir e implementar imágenes, lo que a
+su vez nos permite producir imágenes consistentes y repetibles.
 
-Estos son casos de uso aplicados en la industria: footnote:[https://www.packer.io/intro/use-cases]
+Estos son casos de uso aplicados en la industria:
+footnote:[https://www.packer.io/intro/use-cases]
 
 ==== Consistencia ambiental
-¿Tienes una infraestructura compleja, con numerosos entornos que abarcan desarrollo, pruebas, _staging_ y producción? Packer es ideal para estandarizar esos entornos. Como admite numerosas plataformas de destino, puede crear imágenes estándar para todo tipo de plataformas.
+¿Tienes una infraestructura compleja, con numerosos entornos que abarcan
+desarrollo, pruebas, _staging_ y producción? Packer es ideal para estandarizar
+esos entornos. Como admite numerosas plataformas de destino, puede crear
+imágenes estándar para todo tipo de plataformas.
 
-Por ejemplo, un equipo de seguridad puede usar Packer para crear imágenes que luego se comparten con otros grupos para proporcionar el “hardening” de base que para imponer estándares entre equipos.
+Por ejemplo, un equipo de seguridad puede usar Packer para crear imágenes que
+luego se comparten con otros grupos para proporcionar el “hardening” de base
+que para imponer estándares entre equipos.
 
 ==== Entrega continua
-Packer se integra bien con las herramientas de infraestructura existentes. Se puede agregar en un pipeline de implementación. Es decir, parte del pipeline será crear la imagen. Un ejemplo de esto es la fase _Bake_ de _Spinnaker_ footnote:[https://spinnaker.io/setup/bakery/#packer-templates].
+Packer se integra bien con las herramientas de infraestructura existentes. Se
+puede agregar en un pipeline de implementación. Es decir, parte del pipeline
+será crear la imagen. Un ejemplo de esto es la fase _Bake_ de _Spinnaker_
+footnote:[https://spinnaker.io/setup/bakery/#packer-templates].
 
-Packer puede crear imágenes de Amazon Machine Images (AMI), después Terraform puede usar esas AMI cuando se crean hosts y servicios y podemos ejecutar Ansible ( periódicamente) para proporcionar la configuración final y mantener nuestros hosts configurados correctamente.
+Packer puede crear imágenes de Amazon Machine Images (AMI), después Terraform
+puede usar esas AMI cuando se crean hosts y servicios y podemos ejecutar
+Ansible ( periódicamente) para proporcionar la configuración final y mantener
+nuestros hosts configurados correctamente.
 
-Esto significa que si necesitamos un nuevo host o tenemos que reemplazar un host que no funciona correctamente, el proceso es rápido y consistente. Nuestra infraestructura se vuelve desechable, reemplazable y repetible. Es decir, manejamos un enfoque de infraestructura inmutable.
+Esto significa que si necesitamos un nuevo host o tenemos que reemplazar un
+host que no funciona correctamente, el proceso es rápido y consistente. Nuestra
+infraestructura se vuelve desechable, reemplazable y repetible. Es decir,
+manejamos un enfoque de infraestructura inmutable.
 
-Los beneficios de una infraestructura inmutable incluyen más consistencia y confiabilidad en la infraestructura y un proceso de implementación más simple y predecible. Mitiga o previene por completo los problemas que son comunes en las infraestructuras mutables, como las diferencias de configuración.
+Los beneficios de una infraestructura inmutable incluyen más consistencia y
+confiabilidad en la infraestructura y un proceso de implementación más simple y
+predecible. Mitiga o previene por completo los problemas que son comunes en las
+infraestructuras mutables, como las diferencias de configuración.
 
 === Instalación de _Packer_
 
-Instalaremos el binario de Packer en nuestro equipo personal para ejecutar la construcción de imagenes en la nube de AWS. Packer se puede instalar de las siguientes formas:
+Instalaremos el binario de Packer en nuestro equipo personal para ejecutar la
+construcción de imagenes en la nube de AWS. Packer se puede instalar de las
+siguientes formas:
 
-- Usando un binario precompilado. 
-- Construyendo desde la fuente. 
+- Usando un binario precompilado.
+- Construyendo desde la fuente.
 
-La forma estandar es usar los binarios que Hashicorp lanza. Este método se recomienda para la mayoría de los usuarios.
+La forma estandar es usar los binarios que Hashicorp lanza. Este método se
+recomienda para la mayoría de los usuarios.
 
 ==== Instalación Manual
 
-Para la instalación manual de _Packer_, necesitamos encontrar el paquete apropiado footnote:[https://www.packer.io/downloads] para nuestro sistema operativo y bajarlo, este será un archivo _zip_.
+Para la instalación manual de _Packer_, necesitamos encontrar el paquete
+apropiado footnote:[https://www.packer.io/downloads] para nuestro sistema
+operativo y bajarlo, este será un archivo _zip_.
 
 Una vez que se haya descargado, procederemos a descomprimir el archivo _zip_.
 
-Finalmente, nos aseguraremos de que `packer` se encuentre disponible en nuestro `PATH`. Esto se realiza de manera diferente, dependiendo el sistema operativo.
+Finalmente, nos aseguraremos de que `packer` se encuentre disponible en nuestro
+`PATH`. Esto se realiza de manera diferente, dependiendo el sistema operativo.
 
 ===== Mac o Linux
 
-Obtenemos la lista de rutas que están disponibles en la variable de entorno `PATH`
+Obtenemos la lista de rutas que están disponibles en la variable de entorno
+`PATH`
 
 [source,batch]
 ----
 echo $PATH
 ----
 
-Movemos el binario de _Packer_ a uno de las rutas listadas. Este comando asume que el binario se encuentra en el archivo de descargas y que `PATH` contiene `/usr/local/bin`, personaliza en caso de las rutas en tu sistema operativo sean diferentes.
+Movemos el binario de _Packer_ a uno de las rutas listadas. Este comando asume
+que el binario se encuentra en el archivo de descargas y que `PATH` contiene
+`/usr/local/bin`, personaliza en caso de las rutas en tu sistema operativo sean
+diferentes.
 
 [source,batch]
 ----
@@ -113,13 +181,17 @@ mv ~/Downloads/packer /usr/local/bin/
 
 ==== Windows
 
-En la siguiente dirección de internet, podemos encontrar las instrucciones exactas para modificar el `PATH` en _Windows_ através de la interfaz gráfica: `https://stackoverflow.com/questions/1618280/where-can-i-set-path-to-make-exe-on-windows`
+En la siguiente dirección de internet, podemos encontrar las instrucciones
+exactas para modificar el `PATH` en _Windows_ através de la interfaz gráfica:
+`https://stackoverflow.com/questions/1618280/where-can-i-set-path-to-make-exe-on-windows`
 
 ==== Instalación con _Homebrew_ en _MacOS_
 
-_Homebrew_ es un manejador de paquetes de fuente abierta para el sistema operativo _MacOS_. Instala la _formula_ oficial de _Packer_ desde la terminal.
+_Homebrew_ es un manejador de paquetes de fuente abierta para el sistema
+operativo _MacOS_. Instala la _formula_ oficial de _Packer_ desde la terminal.
 
-Primero, installamos el _tap_ de _HashiCorp_, un repositorio para todos los paquetes de _Homebrew_ de la compañia:
+Primero, installamos el _tap_ de _HashiCorp_, un repositorio para todos los
+paquetes de _Homebrew_ de la compañia:
 
 [source,batch]
 ----
@@ -142,7 +214,8 @@ brew upgrade hashicorp/tap/packer
 
 ==== Instalación con _Chocolatey_ en _Windows_
 
-_Chocolatey_ es un manejador de paquetes de codigo abierto para _Windows_. Installamos el paquete de _Packer_ desde la linea de comandos.
+_Chocolatey_ es un manejador de paquetes de codigo abierto para _Windows_.
+Installamos el paquete de _Packer_ desde la linea de comandos.
 
 [source,batch]
 ----
@@ -184,7 +257,8 @@ Instalamos `yum-config-manager` para manejar repositorios.
 sudo yum install -y yum-utils
 ----
 
-Usamos `yum-config-manager` para agregar el repositorio oficial de _HachiCorp_ para _Linux_
+Usamos `yum-config-manager` para agregar el repositorio oficial de _HachiCorp_
+para _Linux_
 
 [source,batch]
 ----
@@ -207,7 +281,8 @@ Instalamos `dnf config-manager` para manejar repositorios.
 sudo dnf install -y dnf-plugins-core
 ----
 
-Usamos `dnf config-manager` para agregar el repositorio oficial de _HachiCorp_ para _Linux_
+Usamos `dnf config-manager` para agregar el repositorio oficial de _HachiCorp_
+para _Linux_
 
 [source,batch]
 ----
@@ -241,30 +316,47 @@ Available commands are:
 
 ----
 
-Cualquier sub comando despues de `packer -help` permite aprender más sobre el mismo.
+Cualquier sub comando despues de `packer -help` permite aprender más sobre el
+mismo.
 
 [source,batch]
 ----
 packer -help build
 ----
 
-Con esto finalizamos la instalación de _Packer_ y estamos listos para empezar a construir imagenes en la nube.
+Con esto finalizamos la instalación de _Packer_ y estamos listos para empezar a
+construir imagenes en la nube.
 
 === Construcción de imágenes
 
 Con _Packer_ instalado, estamos listos para crear nuestra primer imagen.
 
-Packer usa una plantilla en formato JSON para definir una imagen. Hay tres secciones principales en el archivo: constructores, aprovisionadores y postprocesamiento.
+Packer usa una plantilla en formato JSON para definir una imagen. Hay tres
+secciones principales en el archivo: constructores, aprovisionadores y
+postprocesamiento.
 
-*Los constructores* son los que determinan qué tipo de imagen vamos crear. Aquí es donde le decimos a Packer que queremos una imagen para AWS en formato AMI o una para Virtualbox en formato OVF.
+*Los constructores* son los que determinan qué tipo de imagen vamos crear. Aquí
+es donde le decimos a Packer que queremos una imagen para AWS en formato AMI o
+una para Virtualbox en formato OVF.
 
-No estamos limitados a un solo constructor. Si necesitamos una imagen idéntica para usarla en AWS y Vagrant, definimos varios constructores. 
+No estamos limitados a un solo constructor. Si necesitamos una imagen idéntica
+para usarla en AWS y Vagrant, definimos varios constructores.
 
-*Los aprovisionadores* son la siguiente sección de un archivo JSON de Packer. Una vez instalado el sistema operativo, se invoca a los aprovisionadores para configurar el sistema. 
+*Los aprovisionadores* son la siguiente sección de un archivo JSON de Packer.
+Una vez instalado el sistema operativo, se invoca a los aprovisionadores para
+configurar el sistema.
 
-Hay una gran cantidad de opciones disponibles, desde scripts de shell básicos hasta el uso de playbooks de Ansible.Lo importante para mantener un enfoque DevOps es usar los mismos scripts que usamos en un servidor de producción pero aplicados a un entorno de desarrollo local con Vagrant. De esta manera el entorno de Desarrollo y Producción mantendrán paridad.
+Hay una gran cantidad de opciones disponibles, desde scripts de shell básicos
+hasta el uso de playbooks de Ansible.Lo importante para mantener un enfoque
+DevOps es usar los mismos scripts que usamos en un servidor de producción pero
+aplicados a un entorno de desarrollo local con Vagrant. De esta manera el
+entorno de Desarrollo y Producción mantendrán paridad.
 
-Por último, están *los postprocesadores*. Estos son opcionales. Por ejemplo, son necesarios para crear Boxes de Vagrant. Estas se generan tomando una imagen genérica en OVF para Virtualbox y empaquetándola como una imagen de Vagrant. Otras opciones comúnmente usadas en los postprocesadores son la compresión de la imagen.
+Por último, están *los postprocesadores*. Estos son opcionales. Por ejemplo,
+son necesarios para crear Boxes de Vagrant. Estas se generan tomando una imagen
+genérica en OVF para Virtualbox y empaquetándola como una imagen de Vagrant.
+Otras opciones comúnmente usadas en los postprocesadores son la compresión de
+la imagen.
 
 
 ==== Pre requisitos
@@ -276,13 +368,18 @@ Para continuar, necesitamos:
 * Las credenciales de _AWS_ configuradas localmente.
 * Crear una llave SSH
 
-Esto está descrito en el Apéndice xref:apendice001.adoc[Creación y configuración de una cuenta de Amazon Web Services]
+Esto está descrito en el Apéndice xref:apendice001.adoc[Creación y
+configuración de una cuenta de Amazon Web Services]
 
 ===== Crear llave SSH
 
-Crearemos una llave  SSH local para conectarnos con el usuario terraform que crearemos en la instancia.
+Crearemos una llave  SSH local para conectarnos con el usuario terraform que
+crearemos en la instancia.
 
-Genera una nueva clave SSH llamada `tf-packer`. El argumento proporcionado con la bandera `-f` crea la clave en el directorio actual y crea dos archivos llamados `tf-packer` y `tf-packer.pub`. Cambie la dirección de correo electrónico.
+Genera una nueva clave SSH llamada `tf-packer`. El argumento proporcionado con
+la bandera `-f` crea la clave en el directorio actual y crea dos archivos
+llamados `tf-packer` y `tf-packer.pub`. Cambie la dirección de correo
+electrónico.
 
 ===== Línea de comandos de Mac o Linux
 
@@ -295,11 +392,15 @@ Cuando se  solicite, presiona Intro para dejar la contraseña en blanco.
 
 ===== Windows con PuTTY
 
-Si estás en una máquina con Windows, usa Putty para generar claves SSH siguiendo las instrucciones del siguiente enlace: https://www.ssh.com/ssh/putty/windows/puttygen/.
+Si estás en una máquina con Windows, usa Putty para generar claves SSH
+siguiendo las instrucciones del siguiente enlace:
+https://www.ssh.com/ssh/putty/windows/puttygen/.
 
 ==== Escribir plantillas de Packer
 
-A continuación crearemos una imagen con Packer en AWS y aprovisionaremos software en ella. Posteriormente usaremos esta imagen con Terraform para crear infraestructura.
+A continuación crearemos una imagen con Packer en AWS y aprovisionaremos
+software en ella. Posteriormente usaremos esta imagen con Terraform para crear
+infraestructura.
 
 Creamos un directorio llamado  `iac-libro-packer`
 [source,bash]
@@ -373,7 +474,11 @@ Creamos la plantilla `imagen.json` de Packer con la siguiente estructura.
 ----
 
 
-El bloque de *variables*  determina las variables de entorno que Packer utilizará para la cuenta de AWS. Esta región debe coincidir con la región donde Terraform implementará la infraestructura, por lo que si la personalizas, tendrás que  personalizar la configuración de Terraform para que coincida (más adelante).
+El bloque de *variables*  determina las variables de entorno que Packer
+utilizará para la cuenta de AWS. Esta región debe coincidir con la región donde
+Terraform implementará la infraestructura, por lo que si la personalizas,
+tendrás que  personalizar la configuración de Terraform para que coincida (más
+adelante).
 
 [source,json]
 ----
@@ -385,7 +490,9 @@ El bloque de *variables*  determina las variables de entorno que Packer utilizar
 }
 ----
 
-El bloque de *constructores* crea una imagen en formato AMI denominada imagen-iac-libro-{{timestamp}} que se basa en una imagen t2.micro de Ubuntu con Elastic Block Storage (EBS).
+El bloque de *constructores* crea una imagen en formato AMI denominada
+imagen-iac-libro-{{timestamp}} que se basa en una imagen t2.micro de Ubuntu con
+Elastic Block Storage (EBS).
 
 [source,json]
 ----
@@ -413,11 +520,15 @@ El bloque de *constructores* crea una imagen en formato AMI denominada imagen-ia
 ]
 ----
 
-Finalmente, el bloque de *aprovisionadores* aprovisiona las instancias con scripts o archivos específicos.
+Finalmente, el bloque de *aprovisionadores* aprovisiona las instancias con
+scripts o archivos específicos.
 
-El primer aprovisionador es un aprovisionador de tipo de archivo y copia la clave SSH pública recién creada en un directorio temporal de la imagen.
+El primer aprovisionador es un aprovisionador de tipo de archivo y copia la
+clave SSH pública recién creada en un directorio temporal de la imagen.
 
-El segundo aprovisionador es uden tipo shell que apunta a la ruta relativa a un script de bash. Packer utiliza estos aprovisionadores para personalizar la imagen.
+El segundo aprovisionador es uden tipo shell que apunta a la ruta relativa a un
+script de bash. Packer utiliza estos aprovisionadores para personalizar la
+imagen.
 
 [source,json]
 ----
@@ -478,7 +589,8 @@ sudo chmod 600 /home/terraform/.ssh/authorized_keys
 sudo chown -R terraform /home/terraform/.ssh
 sudo usermod --shell /bin/bash terraform
 
-# Crear el path GOPATH para el usuario de  Terraform y descargar la aplicación web desde github
+# Crear el path GOPATH para el usuario de  Terraform y descargar la aplicación
+web desde github
 
 sudo -H -i -u terraform -- env bash << EOF
 whoami
@@ -494,11 +606,14 @@ EOF
 ----
 
 
-Este script instala las dependencias necesarias, agrega el usuario terraform al grupo sudo, instala la clave SSH creada anteriormente y descarga una aplicación web  en GoLang de muestra.
+Este script instala las dependencias necesarias, agrega el usuario terraform al
+grupo sudo, instala la clave SSH creada anteriormente y descarga una aplicación
+web  en GoLang de muestra.
 
 ==== Construir la imagen
 
-Ejecuta el comando de construcción de Packer pasando como argumentola plantilla de imagen.
+Ejecuta el comando de construcción de Packer pasando como argumentola plantilla
+de imagen.
 
 Nos cambiamos al directorio `imagenes`
 [source,bash]
@@ -553,15 +668,19 @@ Build 'amazon-ebs' finished.
 us-east-1: ami-06cb92a18a30fec16
 ----
 
-La última línea de la salida es la ID de AMI que debemos pasar a la configuración de Terraform en el siguiente paso.
+La última línea de la salida es la ID de AMI que debemos pasar a la
+configuración de Terraform en el siguiente paso.
 
 
 === Desplegar imagenes de Packer con Terraform
 
 
-La AMI es el artefacto resultant de la ejecución de Packer y está disponible en la cuenta de AWS en la sección Imágenes de EC2. Puedes visitar la consola web de AWS para ver este ID de AMI nuevamente.
+La AMI es el artefacto resultant de la ejecución de Packer y está disponible en
+la cuenta de AWS en la sección Imágenes de EC2. Puedes visitar la consola web
+de AWS para ver este ID de AMI nuevamente.
 
-Para utilizar esta AMI en el entorno de Terraform, creamos un diretorio llamado `instancias`
+Para utilizar esta AMI en el entorno de Terraform, creamos un diretorio llamado
+`instancias`
 [source,bash]
 ----
 $ mkdir instancias
@@ -663,9 +782,13 @@ output "id" {
 
 ----
 
-Edita el atributo ami con el ID de AMI que se generó de la construcción de Packer.
+Edita el atributo ami con el ID de AMI que se generó de la construcción de
+Packer.
 
-Crea un nuevo archivo llamado `terraform.tfvars` y agrega la región donde se almacena la imagen como variable. Si personalizaste la región que te dio a Packer, debes cambiar esta región para que coincida, o Terraform no podrá acceder a la imagen.
+Crea un nuevo archivo llamado `terraform.tfvars` y agrega la región donde se
+almacena la imagen como variable. Si personalizaste la región que te dio a
+Packer, debes cambiar esta región para que coincida, o Terraform no podrá
+acceder a la imagen.
 
 [source,bash]
 ----
@@ -679,20 +802,26 @@ Guarda este archivo y luego inicializa y aplica la configuración de Terraform.
 $ terraform init && terraform apply
 ----
 
-Escriba sí cuando se  solicite crear la instancia. El resultado final es la dirección IP de la instancia. 
+Escriba sí cuando se  solicite crear la instancia. El resultado final es la
+dirección IP de la instancia.
 
-La instancia ya contiene la llave SSH para realizar la conexión , porque terraform usó la AMI que se construyó previamente con Packer. El uso de una AMI construida con Packer hace que la implementación de instancias masivas sea más rápida y coherente que la configuración manual de las instancias.
+La instancia ya contiene la llave SSH para realizar la conexión , porque
+terraform usó la AMI que se construyó previamente con Packer. El uso de una AMI
+construida con Packer hace que la implementación de instancias masivas sea más
+rápida y coherente que la configuración manual de las instancias.
 
 ==== Verificar la instancia
 
-Conectate a la instancia a través de SSH con el atributo obteniendo la ip del atributo `aws_instance.web.public_ip` 
+Conectate a la instancia a través de SSH con el atributo obteniendo la ip del
+atributo `aws_instance.web.public_ip`
 
 [source,bash]
 ----
 $ ssh terraform@$(echo "aws_instance.web.public_ip" | terraform console) -i ../tf-packer
 ----
 
-Ahora tienes acceso SSH a tus instancias de AWS sin crear una clave SSH en AWS. Esto es útil si tu organización mantiene pares de claves fuera de AWS.
+Ahora tienes acceso SSH a tus instancias de AWS sin crear una clave SSH en AWS.
+Esto es útil si tu organización mantiene pares de claves fuera de AWS.
 
 Navega hasta el directorio de Go.
 [source,bash]
@@ -704,12 +833,14 @@ Inicie la aplicación web demo.
 ----
 $ go run webapp.go
 ----
-En el navegador web, navega hasta la dirección IP de la instancia y el puerto 8080 para ver la aplicación que implementaste.
+En el navegador web, navega hasta la dirección IP de la instancia y el puerto
+8080 para ver la aplicación que implementaste.
 
 
 ==== Destruye la instancia
 
-Evita cargos innecesarios en tu cuenta de AWS destruyendo su instancia en Terraform.
+Evita cargos innecesarios en tu cuenta de AWS destruyendo su instancia en
+Terraform.
 [source,bash]
 ----
 $ terraform destruir
@@ -717,4 +848,4 @@ $ terraform destruir
 
 Escribe sí cuando se  solicite en la terminal la confirmación.
 
-Esto no destruirá la imagen de Packer. 
+Esto no destruirá la imagen de Packer.


### PR DESCRIPTION
Este PR agrega un target `make fold` y lo usa para convertir los textos de
asciidoc a 80 caracteres de ancho.

El target fold fue agregado para formatear los archivos de texto de 
asciidoc para que seán de una longitud maxima de 80 caracteres.

En contraparte hay partes de los documentos que son URL o salidas de 
consola que son mayores a 80 caracteres y se rompen. Estos errores hay que
arreglaromos manualmente.

Se uso el comando `make fold` para convertir a 80 caracteres de ancho a
todo los archivos de asciidocs. Además se correiguieron algunos errores
introducidos por el mismo comando.

close #24